### PR TITLE
Add support for OpenFlow 1.0.  Tested against OpenDaylight Hydrogen

### DIFF
--- a/twink/ofp1/__init__.py
+++ b/twink/ofp1/__init__.py
@@ -1,0 +1,468 @@
+import struct
+import collections
+
+class _enum_base(object):
+    numbers = None
+    bitshifts = None
+    def items(self):
+        ret = []
+        if self.numbers is None:
+            pass
+        elif isinstance(self.numbers, str):
+            vs = self.numbers.split()
+            ret += zip(vs, range(len(vs)))
+        elif isinstance(self.numbers, dict):
+            for k,v in self.numbers.items():
+                for ki in k.split():
+                    ret.append((ki, v))
+                    v += 1
+        else:
+            raise ValueError(self.numbers)
+        
+        ret += self.items_bitshifts()
+        
+        return ret
+    
+    def items_bitshifts(self):
+        ret = []
+        if self.bitshifts is None:
+            pass
+        elif isinstance(self.bitshifts, str):
+            vs = self.bitshifts.split()
+            for k,v in zip(vs, range(len(vs))):
+                if v<0:
+                    ret.append((k, 0))
+                else:
+                    ret.append((k, 1<<v))
+        elif isinstance(self.bitshifts, dict):
+            for k,v in self.bitshifts.items():
+                for ki in k.split():
+                    if v < 0:
+                        ret.append((ki, 0))
+                    else:
+                        ret.append((ki, 1<<v))
+                    v += 1
+        else:
+            raise ValueError(self.bitshifts)
+        
+        return ret
+    
+    def __init__(self, scope):
+        for k,v in self.items():
+            scope[self.prefix+"_"+k] = v
+    
+    def name(self, value):
+        for k,v in self.items():
+            if v == value:
+                return self.prefix+"_"+k
+    
+    def bitnames(self, value):
+        nohit = None
+        ret = []
+        for k,v in self.items_bitshifts():
+            if k.endswith("_MASK"):
+                continue
+            if value & v:
+                ret.append(self.prefix+"_"+k)
+            elif v == 0:
+                nohit = self.prefix+"_"+k
+        if not ret and nohit:
+            return [nohit,]
+        return ret
+    
+    def values(self):
+        return [v for k,v in self.items()]
+    
+    def keys(self):
+        return [k for k,v in self.items()]
+
+# special definition
+OFP_NO_BUFFER = 0xffffffff
+
+# 6.4 and 7.3.4.1
+ofp_flow_mod_command = type("ofp_flow_mod_command", (_enum_base,), {
+    "prefix": "OFPFC",
+    "numbers": "ADD MODIFY MODIFY_STRICT DELETE DELETE_STRICT"
+    })(globals())
+
+ofp_type = type("ofp_type", (_enum_base,), {
+    "prefix": "OFPT",
+    "numbers": '''HELLO ERROR ECHO_REQUEST ECHO_REPLY VENDOR 
+        FEATURES_REQUEST FEATURES_REPLY GET_CONFIG_REQUEST GET_CONFIG_REPLY SET_CONFIG
+        PACKET_IN FLOW_REMOVED PORT_STATUS
+        PACKET_OUT FLOW_MOD PORT_MOD 
+        STATS_REQUEST STATS_REPLY
+        BARRIER_REQUEST BARRIER_REPLY
+        QUEUE_GET_CONFIG_REQUEST QUEUE_GET_CONFIG_REPLY'''
+    })(globals())
+
+ofp_port_config = type("ofp_port_config", (_enum_base,), {
+    # XXX There're two definitions, each in 7.2.1 and A.6.8
+    "prefix": "OFPPC",
+    "bitshifts": "PORT_DOWN NO_STP NO_RECV NO_RECV_STP NO_FLOOD NO_FWD NO_PACKET_IN"
+    })(globals())
+
+ofp_port_state = type("ofp_port_state", (_enum_base,), {
+    "prefix": "OFPPS",
+    "bitshifts": "LINK_DOWN BLOCKED LIVE"
+    })(globals())
+
+ofp_port_no = type("ofp_port_no", (_enum_base,), {
+    "prefix": "OFPP",
+    "numbers": {
+        "MAX":        0xffffff00,
+        "IN_PORT":    0xfffffff8,
+        "TABLE":      0xfffffff9,
+        "NORMAL":     0xfffffffa,
+        "FLOOD":      0xfffffffb,
+        "ALL":        0xfffffffc,
+        "CONTROLLER": 0xfffffffd,
+        "LOCAL":      0xfffffffe,
+        "ANY":        0xffffffff }
+    })(globals())
+
+ofp_port_features = type("ofp_port_features", (_enum_base,), {
+    "prefix": "OFPPF",
+    "bitshifts": '''10MB_HD 10MB_FD 100MB_HD 100MB_FD 1GB_HD 1GB_FD
+        10GB_FD 40GB_FD 100GB_FD 1TB_FD OTHER
+        COPPER FIBER AUTONEG PAUSE PAUSE_ANY'''
+    })(globals())
+
+ofp_queue_properties = type("ofp_queue_properties", (_enum_base,), {
+    "prefix": "OFPQT",
+    "numbers": {
+        "MIN_RATE": 1,
+        "MAX_RATE": 2,
+        "EXPERIMENTER": 0xffff }
+    })(globals())
+
+ofp_match_type = type("ofp_match_type", (_enum_base,), {
+    "prefix": "OFPMT",
+    "numbers": "STANDARD OXM"
+    })(globals())
+
+ofp_oxm_class = type("ofp_oxm_class", (_enum_base,), {
+    "prefix": "OFPXMC",
+    "numbers": {
+        "NXM_0":          0x0000,
+        "NXM_1":          0x0001,
+        "OPENFLOW_BASIC": 0x8000,
+        "EXPERIMENTER":   0xFFFF }
+    })(globals())
+
+ofp_match_fields = type("ofp_match_fields", (_enum_base,), {
+    "prefix": "OFPXMT_OFB",
+    "numbers": '''IN_PORT IN_PHY_PORT METADATA
+        ETH_DST ETH_SRC ETH_TYPE VLAN_VID VLAN_PCP
+        IP_DSCP IP_ECN IP_PROTO IPV4_SRC IPV4_DST
+        TCP_SRC TCP_DST UDP_SRC UDP_DST SCTP_SRC SCTP_DST
+        ICMPV4_TYPE ICMPV4_CODE
+        ARP_OP ARP_SPA ARP_TPA ARP_SHA ARP_THA
+        IPV6_SRC IPV6_DST IPV6_FLABEL
+        ICMPV6_TYPE ICMPV6_CODE
+        IPV6_ND_TARGET IPV6_ND_SLL IPV6_ND_TLL
+        MPLS_LABEL MPLS_TC MPLS_BOS
+        PBB_ISID TUNNEL_ID IPV6_EXTHDR'''
+    })(globals())
+
+ofp_vlan_id = type("ofp_vlan_id", (_enum_base,), {
+    "prefix": "OFPVID",
+    "numbers": {
+        "PRESENT": 0x1000,
+        "NONE":    0x0000 }
+    })(globals())
+
+ofp_ipv6exthdr_flags = type("ofp_ipv6exthdr_flags", (_enum_base,), {
+    "prefix": "OFPIEH",
+    "bitshifts":"NONEXT ESP AUTH DEST FRAG ROUTER HOP UNREP UNSEQ"
+    })(globals())
+
+# 7.2.5
+ofp_action_type = type("ofp_action_type", (_enum_base,), {
+    "prefix": "OFPAT",
+    "numbers": { '''OUTPUT SET_VLAN_VID SET_VLAN_PCP STRIP_VLAN 
+        SET_DL_SRC SET_DL_DST SET_NW_SRC SET_NW_DST SET_NW_TOS 
+        SET_TP_SRC SET_TP_DST ENQUEUE''': 0,
+        "VENDOR": 0xffff}
+    })(globals())
+
+ofp_controller_max_len = type("ofp_controller_max_len", (_enum_base,), {
+    "prefix": "OFPCML",
+    "numbers": {
+        "MAX":       0xffe5,
+        "NO_BUFFER": 0xffff}
+    })(globals())
+
+ofp_capabilities = type("ofp_capabilities", (_enum_base,), {
+    "prefix": "OFPC",
+    "bitshifts": '''FLOW_STATS TABLE_STATS PORT_STATS STP 
+        RESERVED IP_REASM QUEUE_STATS ARP_MATCH_IP'''
+    })(globals())
+
+ofp_config_flags = type("ofp_config_flags", (_enum_base,), {
+    "prefix": "OFPC_FRAG",
+    "numbers": "NORMAL DROP REASM MASK"
+    })(globals())
+
+ofp_table = type("ofp_table", (_enum_base,), {
+    "prefix": "OFPTT",
+    "numbers": {
+        "MAX": 0xfe,
+        "ALL": 0xff }
+    })(globals())
+
+ofp_table_config = type("ofp_table_config", (_enum_base,), {
+    "prefix": "OFPTC",
+    "numbers": {
+        "DEPRECATED_MASK": 3 }
+    })(globals())
+
+ofp_flow_mod_flags = type("ofp_flow_mod_flags", (_enum_base,), {
+    "prefix": "OFPFF",
+    "bitshifts":"SEND_FLOW_REM CHECK_OVERLAP EMERG"
+    })(globals())
+
+ofp_group_mod_command = type("ofp_group_mod_command", (_enum_base,), {
+    "prefix": "OFPGC",
+    "numbers": "ADD MODIFY DELETE"
+    })(globals())
+
+ofp_group_type = type("ofp_group_type", (_enum_base,), {
+    "prefix": "OFPGT",
+    "numbers": "ALL SELECT INDIRECT FF"
+    })(globals())
+
+ofp_group = type("ofp_group", (_enum_base,), {
+    "prefix": "OFPG",
+    "numbers": {
+        "MAX": 0xffffff00,
+        "ALL": 0xfffffffc,
+        "ANY": 0xffffffff }
+    })(globals())
+
+ofp_meter = type("ofp_meter", (_enum_base,), {
+    "prefix": "OFPM",
+    "numbers": {
+        "MAX":        0xffff0000,
+        "SLOWPATH":   0xfffffffd,
+        "CONTROLLER": 0xfffffffe,
+        "ALL":        0xffffffff }
+    })(globals())
+
+ofp_meter_flags = type("ofp_meter_flags", (_enum_base,), {
+    "prefix": "OFPMF",
+    "bitshifts":"KBPS PKTPS BURST STATS"
+    })(globals())
+
+ofp_meter_band_type = type("ofp_meter_band_type", (_enum_base,), {
+    "prefix": "OFPMBT",
+    "numbers": {
+        "DROP": 1,
+        "DSCP_REMARK": 2,
+        "EXPERIMENTER": 0xFFFF }
+    })(globals())
+
+ofp_stats_type = type("ofp_stats_type", (_enum_base,), {
+    "prefix": "OFPST",
+    "numbers": {
+        '''DESC FLOW AGGREGATE TABLE PORT QUEUE''': 0,
+        "VENDOR": 0xffff}
+    })(globals())
+
+ofp_stats_reply_flags = type("ofp_stats_reply_flags", (_enum_base,), {
+    "prefix": "OFPSF",
+    "numbers": { "REPLY_MORE": 1 }
+    })(globals())
+
+
+ofp_table_feature_prop_type = type("ofp_table_feature_prop_type", (_enum_base,), {
+    "prefix": "OFPTFPT",
+    "numbers": {
+        '''INSTRUCTIONS INSTRUCTIONS_MISS
+        NEXT_TABLES NEXT_TABLES_MISS
+        WRITE_ACTIONS WRITE_ACTIONS_MISS
+        APPLY_ACTIONS APPLY_ACTIONS_MISS
+        MATCH
+        WILDCARDS
+        WRITE_SETFIELD WRITE_SETFIELD_MISS
+        APPLY_SETFIELD APPLY_SETFIELD_MISS''':0,
+        "EXPERIMENTER EXPERIMENTER_MISS": 0xFFFE }
+    })(globals())
+
+ofp_group_capabilities = type("ofp_group_capabilities", (_enum_base,), {
+    "prefix": "OFPGFC",
+    "bitshifts":"SELECT_WEIGHT SELECT_LIVENESS CHAINING CHAINING_CHECKS"
+    })(globals())
+
+ofp_controller_role = type("ofp_controller_role", (_enum_base,), {
+    "prefix": "OFPCR_ROLE",
+    "numbers": "NOCHANGE EQUAL MASTER SLAVE"
+    })(globals())
+
+ofp_packet_in_reason = type("ofp_packet_in_reason", (_enum_base,), {
+    "prefix": "OFPR",
+    "numbers": "NO_MATCH ACTION"
+    })(globals())
+
+ofp_flow_removed_reason = type("ofp_flow_removed_reason", (_enum_base,), {
+    "prefix": "OFPRR",
+    "numbers": "IDLE_TIMEOUT HARD_TIMEOUT DELETE"
+    })(globals())
+
+ofp_port_reason = type("ofp_port_reason", (_enum_base,), {
+    "prefix": "OFPPR",
+    "numbers": "ADD DELETE MODIFY"
+    })(globals())
+
+ofp_error_type = type("ofp_error_type", (_enum_base,), {
+    "prefix": "OFPET",
+    "numbers": '''HELLO_FAILED BAD_REQUEST BAD_ACTION 
+        FLOW_MOD_FAILED PORT_MOD_FAILED QUEUE_OP_FAILED'''
+    })(globals())
+
+ofp_hello_failed_code = type("ofp_hello_failed_code", (_enum_base,), {
+    "prefix": "OFPHFC",
+    "numbers": "INCOMPATIBLE EPERM"
+    })(globals())
+
+ofp_bad_request_code = type("ofp_bad_request_code", (_enum_base,), {
+    "prefix": "OFPBRC",
+    "numbers": '''BAD_VERSION BAD_TYPE BAD_STAT BAD_VENDOR 
+        BAD_SUBTYPE EPERM BAD_LEN BUFFER_EMPTY BUFFER_UNKNOWN'''
+    })(globals())
+
+ofp_bad_action_code = type("ofp_bad_action_code", (_enum_base,), {
+    "prefix": "OFPBAC",
+    "numbers": '''BAD_TYPE BAD_LEN BAD_VENDOR BAD_VENDOR_TYPE 
+        BAD_OUT_PORT BAD_ARGUMENT EPERM TOO_MANY BAD_QUEUE'''
+    })(globals())
+
+ofp_bad_instruction_code = type("ofp_bad_instruction_code", (_enum_base,), {
+    "prefix": "OFPBIC",
+    "numbers": '''UNKNOWN_INST UNSUP_INST BAD_TABLE_ID 
+        UNSUP_METADATA UNSUP_METADATA_MASK 
+        BAD_EXPERIMENTER BAD_EXP_TYPE BAD_LEN EPERM'''
+    })(globals())
+
+ofp_bad_match_code = type("ofp_bad_match_code", (_enum_base,), {
+    "prefix": "OFPBMC",
+    "numbers": '''BAD_TYPE BAD_LEN BAD_TAG 
+        BAD_DL_ADDR_MASK BAD_NW_ADDR_MASK BAD_WILDCARDS 
+        BAD_FIELD BAD_VALUE BAD_MASK BAD_PREREQ
+        DUP_FIELD EPERM'''
+    })(globals())
+
+
+ofp_flow_mod_failed_code = type("ofp_flow_mod_failed_code", (_enum_base,), {
+    "prefix": "OFPFMFC",
+    "numbers": '''ALL_TABLES_FULL OVERLAP EPERM 
+        BAD_EMERG_TIMEOUT BAD_COMMAND UNSUPPORTED'''
+    })(globals())
+
+ofp_port_mod_failed_code = type("ofp_port_mod_failed_code", (_enum_base,), {
+    "prefix": "OFPPMFC",
+    "numbers": "BAD_PORT BAD_HW_ADDR"
+    })(globals())
+
+ofp_queue_op_failed_code = type("ofp_queue_op_failed_code", (_enum_base,), {
+    "prefix": "OFPQOFC",
+    "numbers": "BAD_PORT BAD_QUEUE EPERM"
+    })(globals())
+
+ofp_switch_config_failed_code = type("ofp_switch_config_failed_code", (_enum_base,), {
+    "prefix": "OFPSCFC",
+    "numbers": "BAD_FLAGS BAD_LEN EPERM"
+    })(globals())
+
+ofp_role_request_failed_code = type("ofp_role_request_failed_code", (_enum_base,), {
+    "prefix": "OFPRRFC",
+    "numbers": "STALE UNSUP BAD_ROLE"
+    })(globals())
+
+ofp_table_features_failed_code = type("ofp_table_features_failed_code", (_enum_base,), {
+    "prefix": "OFPTFFC",
+    "numbers": "BAD_TABLE BAD_METADATA BAD_TYPE BAD_LEN BAD_ARGUMENT EPERM"
+    })(globals())
+
+ofp_hello_enum_type = type("ofp_hello_enum_type", (_enum_base,), {
+    "prefix": "OFPHET",
+    "numbers": { "VERSIONBITMAP":1 }
+    })(globals())
+
+ofp_flow_wildcards = type("ofp_flow_wildcards", (_enum_base,), {
+    "prefix": "OFPFW",
+    "numbers": {
+        "IN_PORT": 1<<0,
+        "DL_VLAN": 1<<1,
+        "DL_SRC": 1<<2,
+        "DL_DST": 1<<3,
+        "DL_TYPE": 1<<4,
+        "NW_PROTO": 1<<5,
+        "TP_SRC": 1<<6,
+        "TP_DST": 1<<7,
+        "NW_SRC_SHIFT": 8,
+        "NW_SRC_BITS": 6,
+        "NW_SRC_MASK": 0x3f<<8,
+        "NW_DST_SHIFT": 14,
+        "NW_DST_BITS": 6,
+        "NW_DST_MASK": 0x3f<<14,
+        "NW_DST_ALL": 32<<14,
+        "ALL": 0xfffff }
+    })(globals())
+
+ofp_flow_expired_readon = type("ofp_flow_expired_readon", (_enum_base,), {
+    "prefix": "OFPER",
+    "numbers": "IDLE_TIMEOUT HARD_TIMEOUT"
+    })(globals())
+
+
+def ofptuple(etherframe, in_port=None):
+    '''
+    returns an openflow v1.0 12 tuple without the first in_port
+    '''
+    (ethernet_dst, ethernet_src, ethernet_type, tci, inner_type) = struct.unpack_from("!6s6sHHH", etherframe)
+    if ethernet_type == 0x8100:
+        vlan_id = tci&0x0FFF
+        vlan_priority = tci>>13
+        ethernet_type = inner_type
+        offset = 4
+    else:
+        vlan_id = None
+        vlan_priority = None
+        offset = 0
+    
+    if ethernet_type < 0x05DC:
+        (llc_dsap, llc_ssap, llc_ctl, snap_oui, snap_type) = struct.unpack_from("!BBB3sH", etherframe, offset=14)
+        if llc_dsap==0xAA and llc_ssap==0xAA and snap_oui=="0x00"*3:
+            ethernet_type = snap_type
+            offset = 8
+    
+    ip_tos = ip_protocol = ip_src = ip_dst = None
+    transport_src_port_or_icmp_type = None
+    transport_dst_port_or_icmp_code = None
+    if ethernet_type == 0x0800: # IP
+        (ip_tos, ip_protocol, ip_src, ip_dst, src_port, dst_port) = struct.unpack_from("!xB7xB2x4s4sHH", etherframe, offset=14+offset)
+        if ip_protocol == 1: # ICMP
+            transport_src_port_or_icmp_type = src_port>>8
+            transport_dst_port_or_icmp_code = src_port&0xFF
+        elif ip_protocol in (6, 17): # TCP, UDP
+            transport_src_port_or_icmp_type = src_port
+            transport_dst_port_or_icmp_code = dst_port
+    elif ethernet_type == 0x0806: # ARP
+        # ip_protocol : ARP Operation
+        (ip_protocol, ip_src, ip_dst) = struct.unpack_from("!6xH6x4s6x4s", etherframe, offset=14+offset)
+    
+    return collections.namedtuple("ofptuple", "in_port dl_src dl_dst dl_type dl_vlan dl_vlan_pcp nw_src nw_dst nw_proto ip_tos tp_src tp_dst")(
+        in_port,
+        ethernet_src,
+        ethernet_dst,
+        ethernet_type,
+        vlan_id,
+        vlan_priority,
+        ip_src,
+        ip_dst,
+        ip_protocol,
+        ip_tos,
+        transport_src_port_or_icmp_type,
+        transport_dst_port_or_icmp_code
+        )

--- a/twink/ofp1/build.py
+++ b/twink/ofp1/build.py
@@ -1,0 +1,1036 @@
+from __future__ import absolute_import
+import struct
+import random
+from . import *
+
+_len = len
+_type = type
+
+default_xid = lambda: long(random.random()*0xFFFFFFFF)
+
+def _obj(obj):
+    if isinstance(obj, str):
+        return obj
+    elif isinstance(obj, tuple):
+        return eval(obj.__class__.__name__)(*obj)
+    else:
+        raise ValueError(obj)
+
+def _pack(fmt, *args):
+    if fmt[0] != "!":
+        fmt = "!"+fmt
+    return struct.pack(fmt, *args)
+
+def _unpack(fmt, message, offset):
+    if fmt[0] != "!":
+        fmt = "!"+fmt
+    return struct.unpack_from(fmt, message, offset)
+
+def _align(length):
+    return (length+7)/8*8
+
+# 7.1
+def ofp_header(version, type, length, xid):
+    if version is None:
+        version = 1
+    assert version==1
+    
+    if length is None:
+        length = 8
+    
+    if xid is None:
+        xid = default_xid()
+    
+    return _pack("BBHI", version, type, length, xid)
+
+
+def ofp_(header, data, type=None):
+    if isinstance(header, str):
+        (version, oftype, length, xid) = _unpack("BBHI", header, 0)
+        if isinstance(type, int):
+            assert oftype == type
+        elif isinstance(type, (list,tuple)):
+            assert oftype in type
+        elif type is None:
+            pass
+        else:
+            raise ValueError(type)
+    elif isinstance(header, tuple):
+        (version, oftype, length, xid) = header
+        if isinstance(type, int):
+            if oftype is None:
+                oftype = type
+            else:
+                assert oftype == type
+        elif isinstance(type, (list,tuple)):
+            assert oftype in type
+        elif type is None:
+            assert isinstance(oftype, int)
+        else:
+            raise ValueError(type)
+    elif header is None:
+        version = 1
+        if isinstance(type, int):
+            oftype = type
+        else:
+            raise ValueError(type)
+        xid = default_xid()
+    else:
+        raise ValueError(header)
+    
+    data = _obj(data)
+    length = 8 + _len(data)
+    return ofp_header(version, oftype, length, xid)+data
+
+
+# 7.2.1
+def ofp_port(port_no, hw_addr, name, config, state, curr, advertised, supported, peer):
+    assert isinstance(hw_addr, str) and _len(hw_addr)==6
+    assert isinstance(name, str) and _len(name)<=16
+    msg = _pack("H6s16s6I", 
+        port_no,
+        hw_addr,
+        name,
+        config,
+        state,
+        curr,
+        advertised,
+        supported,
+        peer)
+    assert _len(msg) == 48
+    return msg
+
+# 7.2.2
+def ofp_packet_queue(queue_id, port, len, properties):
+    if isinstance(properties, str):
+        pass
+    elif isinstance(properties, (list, tuple)):
+        properties = "".join([_obj(p) for p in properties])
+    elif properties is None:
+        properties = ""
+    else:
+        raise ValueError(properties)
+    
+    len = 16 + _len(properties)
+    
+    desc = _pack("IIH6x",
+        queue_id,
+        port,
+        len)
+    assert _len(desc)==16
+    return desc + properties
+
+def ofp_queue_prop_header(property, len):
+    if len is None:
+        len = 8
+    msg = _pack("HH4x",
+        property,
+        len)
+    assert _len(msg)==8
+    return msg
+
+def ofp_queue_prop_(prop_header, data, type=None):
+    if isinstance(prop_header, str):
+        (property,len) = _unpack("HH", prop_header, 0)
+        if isinstance(type, int):
+            assert property==type
+        elif isinstance(type, (list, tuple)):
+            assert property in type
+        elif type is None:
+            pass
+        else:
+            raise ValueError(type)
+    elif isinstance(prop_header, (list, tuple)):
+        (property,len) = prop_header
+        if isinstance(type, int):
+            if property is None:
+                property = type
+            else:
+                assert property==type
+        elif isinstance(type, (list, tuple)):
+            assert property in type
+        elif type is None:
+            assert isinstance(property, int)
+        else:
+            raise ValueError(type)
+    elif prop_header is None:
+        property = type
+    else:
+        raise ValueError(prop_header)
+    
+    data = _obj(data)
+    len = _len(data) + 8
+    return ofp_queue_prop_header(property,len)+data
+
+def ofp_queue_prop_min_rate(prop_header, rate):
+    msg = ofp_queue_prop_(prop_header,
+        _pack("H6x", rate),
+        OFPQT_MIN_RATE)
+    assert _len(msg)==16
+    return msg
+
+def ofp_queue_prop_max_rate(prop_header, rate):
+    msg = ofp_queue_prop_(prop_header,
+        _pack("H6x", rate),
+        OFPQT_MAX_RATE)
+    assert _len(msg)==16
+    return msg
+
+def ofp_queue_prop_experimenter(prop_header, experimenter, data):
+    msg = ofp_queue_prop_(prop_header, 
+        _pack("I4x", experimenter)+data,
+        OFPQT_EXPERIMENTER)
+    return msg
+
+# 7.2.3.1
+def ofp_match(type, length, oxm_fields):
+    '''type: OFPMT_STANDARD/OXM
+    '''
+    if type is None:
+        type = OFPMT_OXM
+    
+    if isinstance(oxm_fields, str):
+        pass
+    elif isinstance(oxm_fields, (list, tuple)):
+        oxm_fields = "".join([_obj(f) for f in oxm_fields])
+    elif oxm_fields is None:
+        oxm_fields = ""
+    else:
+        ValueError(oxm_fields)
+    
+    length = 4 + _len(oxm_fields)
+    
+    msg = _pack("HH", type, length) + oxm_fields + "\0"*(_align(length)-length)
+    assert _len(msg) % 8 == 0
+    return msg
+
+# 7.2.4
+def ofp_instruction(type, len):
+    return _pack("HH", type, len)
+
+def ofp_instruction_goto_table(type, len, table_id):
+    if type is None:
+        type = OFPIT_GOTO_TABLE
+    assert type==OFPIT_GOTO_TABLE
+    len = 8
+    msg = _pack("HHB3x",
+        type,
+        len,
+        table_id)
+    assert _len(msg)==8
+    return msg
+
+def ofp_instruction_write_metadata(type, len, metadata, metadata_mask):
+    if type is None:
+        type = OFPIT_WRITE_METADATA
+    assert type==OFPIT_WRITE_METADATA
+    len = 24
+    msg = _pack("HH4xQQ",
+        type,
+        len,
+        metadata,
+        metadata_mask)
+    assert _len(msg)==24
+    return msg
+
+def ofp_instruction_actions(type, len, actions):
+    '''type: OFPIT_WRITE_ACTIONS/APPLY_ACTIONS/CLEAR_ACTIONS
+    '''
+    if isinstance(actions, str):
+        pass
+    elif isinstance(actions, (tuple, list)):
+        actions = "".join([_obj(a) for a in actions])
+    elif actions is None:
+        actions = ""
+    else:
+        raise ValueError(actions)
+    
+    assert type in (OFPIT_WRITE_ACTIONS, OFPIT_APPLY_ACTIONS, OFPIT_CLEAR_ACTIONS)
+    
+    len = 8 + _len(actions)
+    msg = _pack("HH4x",
+        type,
+        len) + actions
+    return msg
+
+def ofp_instruction_meter(type, len, meter_id):
+    if type is None:
+        type = OFPIT_METER
+    assert type==OFPIT_METER
+    len = 8
+    msg = _pack("HHI",
+        type,
+        len,
+        meter_id)
+    return msg
+
+def ofp_instruction_experimenter(type, len, experimenter, data):
+    if type is None:
+        type = OFPIT_EXPERIMENTER
+    assert type == OFPIT_EXPERIMENTER
+    
+    data = _obj(data)
+    
+    len = 8 + _len(data)
+    
+    msg = _pack("HHI",
+        type,
+        len,
+        experimenter) + data
+    return msg
+
+# 7.2.5
+def ofp_action_header(type, len):
+    return _pack("HH4x", type, len)
+
+def ofp_action_output(type, len, port, max_len):
+    '''max_len: OFP_CML_MAX/NO_BUFFER
+    '''
+    if type is None:
+        type = OFPAT_OUTPUT
+    assert type == OFPAT_OUTPUT
+    
+    len = 16
+    
+    msg = _pack("HHIH6x",
+        type,
+        len,
+        port,
+        max_len)
+    assert _len(msg) == 16
+    return msg
+
+def ofp_action_group(type, len, group_id):
+    if type is None:
+        type = OFPAT_GROUP
+    assert type == OFPAT_GROUP
+    
+    len = 8
+    
+    msg = _pack("HHI",
+        type,
+        len,
+        group_id)
+    assert _len(msg) == 8
+    return msg
+
+def ofp_action_set_queue(type, len, queue_id):
+    if type is None:
+        type = OFPAT_SET_QUEUE
+    assert type == OFPAT_SET_QUEUE
+    
+    len = 8
+    
+    msg = _pack("HHI",
+        type,
+        len,
+        queue_id)
+    assert _len(msg) == 8
+    return msg
+
+def ofp_action_mpls_ttl(type, len, mpls_ttl):
+    if type is None:
+        type = OFPAT_SET_MPLS_TTL
+    assert type == OFPAT_SET_MPLS_TTL
+    
+    len = 8
+    
+    msg = _pack("HHB3x",
+        type,
+        len,
+        mpls_ttl)
+    assert _len(msg) == 8
+    return msg
+
+def ofp_action_nw_ttl(type, len, nw_ttl):
+    if type is None:
+        type = OFPAT_SET_NW_TTL
+    assert type == OFPAT_SET_NW_TTL
+    
+    len = 8
+    
+    msg = _pack("HHB3x",
+        type,
+        len,
+        nw_ttl)
+    assert _len(msg) == 8
+    return msg
+
+def ofp_action_push(type, len, ethertype):
+    '''type: OFPAT_PUSH_VLAN/PUSH_MPLS/PUSH_PBB
+    '''
+    assert type in (OFPAT_PUSH_VLAN, OFPAT_PUSH_MPLS, OFPAT_PUSH_PBB)
+    
+    len = 8
+    
+    msg = _pack("3H2x",
+        type,
+        len,
+        ethertype)
+    assert _len(msg) == 8
+    return msg
+
+def ofp_action_pop_mpls(type, len, ethertype):
+    if type is None:
+        type = OFPAT_POP_MPLS
+    assert type == OFPAT_POP_MPLS
+    
+    len = 8
+    
+    msg = _pack("3H2x",
+        type,
+        len,
+        ethertype)
+    assert _len(msg) == 8
+    return msg
+
+def ofp_action_set_field(type, len, field):
+    if type is None:
+        type = OFPAT_SET_FIELD
+    assert type == OFPAT_SET_FIELD
+    
+    assert isinstance(field, str)
+    
+    filled_len = 4 + _len(field)
+    len = _align(filled_len)
+    
+    return _pack("HH", type, len) + field + '\0'*(len-filled_len)
+
+def ofp_action_experimenter_(type, len, experimenter, data):
+    if type is None:
+        type = OFPAT_EXPERIMENTER
+    assert type == OFPAT_EXPERIMENTER
+    
+    assert isinstance(data, str)
+    
+    filled_len = 8 + _len(data)
+    len = _align(filled_len)
+    
+    return _pack("HHI", type, len, experimenter) + data + '\0'*(len-filled_len)
+
+# 7.3.1
+def ofp_switch_features(header, datapath_id, n_buffers, n_tables, capabilities, actions, data):
+    length = 32 + len(data)
+    msg = ofp_(header, _pack("QIB3xII",
+        datapath_id,
+        n_buffers,
+        n_tables,
+        capabilities,
+        actions) + data, 
+        OFPT_FEATURES_REPLY)
+    assert _len(msg) == length
+    return msg
+
+# 7.3.2
+def ofp_switch_config(header, flags, miss_send_len):
+    if miss_send_len is None:
+        miss_send_len = OFPCML_NO_BUFFER
+    msg = ofp_(header, _pack("HH",
+        flags,
+        miss_send_len), (OFPT_SET_CONFIG, OFPT_GET_CONFIG_REPLY))
+    assert _len(msg) == 12
+    return msg
+
+# 7.3.4.1
+def ofp_flow_mod(header, cookie, cookie_mask, table_id, command,
+        idle_timeout, hard_timeout, priority, buffer_id, out_port, out_group, flags,
+        match, instructions):
+    '''command=OFPFC_ADD/MODIFY/MODIFY_STRICT/DELETE/DELETE_STRICT
+    '''
+    if isinstance(instructions, str):
+        pass
+    elif isinstance(instructions, (tuple,list)):
+        instructions = "".join([_obj(i) for i in instructions])
+    elif instructions is None:
+        instructions = ""
+    else:
+        raise ValueError(instructions)
+    
+    if buffer_id is None:
+        buffer_id = 0xffffffff # OFP_NO_BUFFER
+    
+    if out_port is None:
+        out_port = OFPP_ANY
+    
+    if out_group is None:
+        out_group = OFPG_ANY
+    
+    msg = ofp_(header, _pack("QQBB3H3IH2x",
+        cookie, cookie_mask,
+        table_id, command,
+        idle_timeout, hard_timeout,
+        priority, buffer_id,
+        out_port, out_group,
+        flags)+_obj(match)+instructions, 
+        OFPT_FLOW_MOD)
+    return msg
+
+def ofp_bucket(len, weight, watch_port, watch_group, actions):
+    if isinstance(actions, str):
+        pass
+    elif isinstance(actions, (list, tuple)):
+        actions = "".join([_obj(a) for a in actions])
+    elif actions is None:
+        actions = ""
+    else:
+        raise ValueError(actions)
+    
+    filled_len = 16 + _len(actions)
+    len = _align(filled_len)
+    
+    msg = _pack("HHII4x",
+        len,
+        weight,
+        watch_port,
+        watch_group) + actions + '\0'*(len-filled_len)
+    return msg
+
+# 7.3.4.3
+def ofp_port_mod(header, port_no, hw_addr, config, mask, advertise):
+    msg = ofp_(header,
+        _pack("I4x6s2xIII4x", port_no, hw_addr, config, mask, advertise),
+        OFPT_PORT_MOD)
+    assert _len(msg)==40
+    return msg
+
+def ofp_meter_band_header(type, len, rate, burst_size):
+    msg = _pack("HHII", type, len, rate, burst_size)
+    assert _len(msg) == 12
+    return msg
+
+def ofp_meter_band_drop(type, len, rate, burst_size):
+    if type is None:
+        type = OFPMBT_DROP
+    assert type == OFPMBT_DROP
+    
+    len = 16
+    
+    msg = _pack("HHII4x",
+        type,
+        len,
+        rate,
+        burst_size)
+    assert _len(msg) == 16
+    return msg
+
+def ofp_meter_band_dscp_remark(type, len, rate, burst_size, prec_level):
+    if type is None:
+        type = OFPMBT_DSCP_REMARK
+    assert type == OFPMBT_DSCP_REMARK
+    
+    len = 16
+    
+    msg = _pack("HHIIB3x",
+        type,
+        len,
+        rate,
+        burst_size,
+        prec_level)
+    assert _len(msg) == 16
+    return msg
+
+def ofp_meter_band_experimenter(type, len, rate, burst_size, experimenter, data):
+    if type is None:
+        type = OFPMBT_EXPERIMENTER
+    assert type == OFPMBT_EXPERIMENTER
+    
+    assert isinstance(data, str)
+    
+    len = 16 + _len(data)
+    # XXX: no _align here in spec
+    
+    msg = _pack("HHIII",
+        type,
+        len,
+        rate,
+        burst_size,
+        experimenter) + data
+    return msg
+
+# 7.3.5
+def ofp_stats_request(header, type, flags, body=None):
+    if type in (OFPST_DESC, OFPST_TABLE, OFPST_GROUP_DESC, 
+            OFPST_GROUP_FEATURES, OFPST_METER_FEATURES, OFPST_PORT_DESC):
+        body = ""
+    elif type in (OFPST_FLOW, OFPST_AGGREGATE, OFPST_PORT_STATS, 
+            OFPST_QUEUE, OFPST_GROUP, OFPST_METER, OFPST_METER_CONFIG):
+        if body is None:
+            body = ""
+        else:
+            body = _obj(body)
+    elif type == OFPST_TABLE_FEATURES:
+        if isinstance(body, str):
+            pass
+        elif isinstance(body, (list, tuple)):
+            body = "".join([_obj(b) for b in body])
+        elif body is None:
+            body = []
+    
+    msg = ofp_(header,
+        _pack("HH4x", type, flags) + body,
+        OFPT_STATS_REQUEST)
+    return msg
+
+def ofp_stats_reply(header, type, flags, body):
+    if type in (OFPST_DESC, OFPST_AGGREGATE):
+        if isinstance(body, (tuple,str)):
+            body = _obj(body)
+        elif body is None:
+            body = ""
+        else:
+            raise ValueError(body)
+    elif type in (OFPST_FLOW, OFPST_TABLE, OFPST_PORT, OFPST_QUEUE):
+        if isinstance(body, (list,tuple)):
+            body = "".join([_obj(b) for b in body])
+        elif body is None:
+            body = ""
+        else:
+            raise ValueError(body)
+    elif type == OFPST_VENDOR:
+        if isinstance(body, str):
+            pass
+        else:
+            raise ValueError(body)
+    else:
+        raise ValueError(type)
+    
+    msg = ofp_(header,
+        _pack("HH", type, flags) + body,
+        OFPT_STATS_REPLY)
+    return msg
+
+# 7.3.5.1
+def ofp_desc(mfr_desc, hw_desc, sw_desc, serial_num, dp_desc):
+    if mfr_desc is None:
+        mfr_desc = ""
+    if hw_desc is None:
+        hw_desc = ""
+    if sw_desc is None:
+        sw_desc = ""
+    if serial_num is None:
+        serial_num = ""
+    if dp_desc is None:
+        dp_desc = ""
+    msg = _pack("256s256s256s32s256s",
+        mfr_desc,
+        hw_desc,
+        sw_desc,
+        serial_num,
+        dp_desc)
+    assert _len(msg) == 1056
+    return msg
+
+# 7.3.5.2
+def ofp_flow_stats_request(table_id, out_port, out_group, cookie, cookie_mask, match):
+    if table_id is None:
+        table_id = OFPTT_ALL
+    if out_port is None:
+        out_port = OFPP_ANY
+    if out_group is None:
+        out_group = OFPG_ANY
+    if cookie is None:
+        cookie = 0
+    if cookie_mask is None:
+        cookie_mask = 0
+    if match is None:
+        match = ofp_match(None, None, [])
+    desc = _pack("B3xII4xQQ", table_id, out_port, out_group, cookie, cookie_mask)
+    assert _len(desc)==32
+    return desc+_obj(match)
+
+def ofp_flow_stats(length, table_id, duration_sec, duration_nsec, priority,
+        idle_timeout, hard_timeout, flags, cookie, packet_count, byte_count,
+        match, instructions):
+    if instructions is None:
+        instructions = ""
+    elif isinstance(instructions, (list, tuple)):
+        instructions = "".join([_obj(i) for i in instructions])
+    elif isinstance(instructions, str):
+        pass
+    else:
+        raise ValueError(instructions)
+    
+    match = _obj(match)
+    
+    length = 48 + _len(match) + _len(instructions)
+    msg = _pack("HBxII4H4x3Q", length, table_id, duration_sec, duration_nsec,
+        priority, idle_timeout, hard_timeout, flags,
+        cookie, packet_count, byte_count)+match+instructions
+    assert _len(msg) == length
+    return msg
+
+# 7.3.5.3
+def ofp_aggregate_stats_request(table_id, out_port, out_group, cookie, cookie_mask, match):
+    if table_id is None:
+        table_id = OFPTT_ALL
+    if out_port is None:
+        out_port = OFPP_ANY
+    if out_group is None:
+        out_group = OFPG_ANY
+    if cookie is None:
+        cookie = 0
+    if cookie_mask is None:
+        cookie_mask = 0
+    desc = _pack("B3xII4xQQ", table_id, out_port, out_group, cookie, cookie_mask)
+    assert len(desc) == 40
+    return desc + _obj(match)
+
+def ofp_aggregate_stats_reply(packet_count, byte_count, flow_count):
+    return _pack("QQI4x", packet_count, byte_count, flow_count)
+
+# 7.3.5.4
+def ofp_table_stats(table_id, table_name, wildcards, max_entries, active_count, lookup_count, matched_count):
+    msg = _pack("B3x32s3IQQ", table_id, table_name, wildcards, max_entries, active_count, lookup_count, matched_count)
+    assert _len(msg) == 64
+    return msg
+
+# 7.3.5.5.1
+def ofp_table_features(length, table_id, name, metadata_match, metadata_write, config, max_entries, properties):
+    if isinstance(properties, (list,tuple)):
+        properties = "".join([_obj(p) for p in properties])
+    elif isinstance(properties, str):
+        pass
+    elif properties is None:
+        properties = ""
+    else:
+        raise ValueError(properties)
+    
+    length = 64 + _len(properties)
+    
+    msg = _pack("HB5x32sQQII", length, table_id, name, metadata_match, metadata_write,
+        config, max_entries) + properties
+    assert _len(msg) == length
+    return msg
+
+# 7.3.5.5.2
+def ofp_table_feature_prop_header(type, length):
+    return _pack("HH", type, length)
+
+def ofp_table_feature_prop_instructions(type, length, instruction_ids):
+    if isinstance(instruction_ids, (list,tuple)):
+        instruction_ids = "".join([_obj(i) for i in instruction_ids])
+    elif isinstance(instruction_ids, str):
+        pass
+    elif instruction_ids is None:
+        instruction_ids = ""
+    else:
+        raise ValueError(instruction_ids)
+    
+    assert type in (OFPTFPT_INSTRUCTIONS, OFPTFPT_INSTRUCTIONS_MISS)
+    
+    length = 4 + _len(instruction_ids)
+    
+    return _pack("HH", type, length) + instruction_ids + '\0'*(_align(length)-length)
+
+def ofp_table_feature_prop_next_tables(type, length, next_table_ids):
+    if isinstance(next_table_ids, (list,tuple)):
+        next_table_ids = "".join([_obj(n) for n in next_table_ids])
+    elif isinstance(next_table_ids, str):
+        pass
+    elif next_table_ids is None:
+        next_table_ids = ""
+    else:
+        raise ValueError(next_table_ids)
+    
+    assert type in (OFPTFPT_NEXT_TABLES, OFPTFPT_NEXT_TABLES_MISS)
+    
+    length = 4 + _len(next_table_ids)
+    
+    return _pack("HH", type, length) + next_table_ids + '\0'*(_align(length)-length)
+
+def ofp_table_feature_prop_actions(type, length, action_ids):
+    if isinstance(action_ids, (list,tuple)):
+        action_ids = "".join([_obj(a) for a in action_ids])
+    elif isinstance(action_ids, str):
+        pass
+    elif action_ids is None:
+        action_ids = ""
+    else:
+        raise ValueError(action_ids)
+    
+    assert type in (OFPTFPT_WRITE_ACTIONS, OFPTFPT_WRITE_ACTIONS_MISS,
+        OFPTFPT_APPLY_ACTIONS, OFPTFPT_APPLY_ACTIONS_MISS)
+    
+    length = 4 + _len(action_ids)
+    
+    return _pack("HH", type, length) + action_ids + '\0'*(_align(length)-length)
+
+def ofp_table_feature_prop_oxm(type, length, oxm_ids):
+    if isinstance(oxm_ids, (list,tuple)):
+        oxm_ids = _pack("%dI" % len(oxm_ids), *oxm_ids)
+    elif isinstance(oxm_ids, str):
+        pass
+    elif oxm_ids is None:
+        oxm_ids = ""
+    else:
+        raise ValueError(oxm_ids)
+    
+    assert type in (OFPTFPT_MATCH, OFPTFPT_WILDCARDS, OFPTFPT_WRITE_SETFIELD, OFPTFPT_WRITE_SETFIELD_MISS, 
+        OFPTFPT_APPLY_SETFIELD, OFPTFPT_APPLY_SETFIELD_MISS)
+    
+    length = 4 + _len(oxm_ids)
+    
+    return _pack("HH", type, length) + oxm_ids + '\0'*(_align(length)-length)
+
+def ofp_table_feature_prop_experimenter(type, length, experimenter, exp_type, data):
+    assert isinsntace(data, str)
+    
+    length = 12 + _len(data)
+    
+    assert type in (OFPTFPT_EXPERIMENTER, OFPTFPT_EXPERIMENTER_MISS)
+    
+    return _pack("HHII", type, length, experimenter, exp_type) + data
+
+# 7.3.5.6
+def ofp_port_stats_request(port_no):
+    if port_no is None:
+        port_no = OFPP_ANY
+    return _pack("I4x", port_no)
+
+def ofp_port_stats(port_no, rx_packets, tx_packets, rx_bytes, tx_bytes, rx_dropped, tx_dropped,
+        rx_errors, tx_errors, rx_frame_err, rx_over_err, rx_crc_err, collisions):
+    return _pack("H6x12q", port_no, rx_packets, tx_packets, rx_bytes, tx_bytes, rx_dropped, tx_dropped,
+        rx_errors, tx_errors, rx_frame_err, rx_over_err, rx_crc_err, collisions)
+
+# 7.3.5.8
+def ofp_queue_stats_request(port_no, queue_id):
+    if port_no is None:
+        port_no = OFPP_ANY
+    if queue_id is None:
+        queue_id = OFPQ_ALL
+    return _pack("II", port_no, queue_id)
+
+def ofp_queue_stats(port_no, queue_id, tx_bytes, tx_packets, tx_errors, duration_sec, duration_nsec):
+    return _pack("2I3Q2I", port_no, queue_id, tx_bytes, tx_packets, tx_errors, duration_sec, duration_nsec)
+
+# 7.3.5.9
+def ofp_group_stats_request(group_id):
+    if group_id is None:
+        group_id = OFPG_ALL
+    return _pack("I4x", group_id)
+
+def ofp_group_stats(length, group_id, ref_count, packet_count, byte_count,
+        duration_sec, duration_nsec, bucket_stats):
+    if isinstance(bucket_stats, (list,tuple)):
+        bucket_stats = "".join([_obj(b) for b in bucket_stats])
+    elif isinstance(bucket_stats, str):
+        pass
+    elif bucket_stats is None:
+        bucket_stats = ""
+    else:
+        raise ValueError(bucket_stats)
+    
+    length = 40 + _len(bucket_stats)
+    
+    return _pack("H2xII4xQQII", length, group_id, ref_count, packet_count, byte_count,
+        duration_sec, duration_nsec) + bucket_stats
+
+def ofp_bucket_counter(packet_count, byte_count):
+    return _pack("QQ", packet_count, byte_count)
+
+# 7.3.5.10
+def ofp_group_desc(length, type, group_id, buckets):
+    if isinstance(buckets, (list,tuple)):
+        buckets = "".join([_obj(b) for b in buckets])
+    elif isinstance(buckets, str):
+        pass
+    elif buckets is None:
+        buckets = ""
+    else:
+        raise ValueError(buckets)
+    
+    length = 8 + _len(buckets)
+    
+    return _pack("HBxI", length, type, group_id) + buckets
+
+# 7.3.5.11
+def ofp_group_features(types, capabilities, max_groups, actions):
+    if isinstance(max_groups, (list,tuple)):
+        max_groups = _pack("4I", *max_groups)
+    elif isinstance(max_groups, str):
+        assert len(max_groups) == 16
+    elif max_groups is None:
+        max_groups = '\0'*16
+    else:
+        raise ValueError(max_groups)
+    
+    if isinstance(actions, (list,tuple)):
+        actions = _pack("4I", *actions)
+    elif isinstance(actions, str):
+        assert len(actions) == 16
+    elif actions is None:
+        actions = '\0'*16
+    else:
+        raise ValueError(actions)
+    
+    return _pack("II", types, capabilities) + max_groups + actions
+
+# 7.3.5.12
+def ofp_meter_stats_request(meter_id):
+    return _pack("I4x", meter_id)
+
+def ofp_meter_stats(meter_id, len, flow_count, packet_in_count, byte_in_count,
+        duration_sec, duration_nsec, band_stats):
+    if isinstance(band_stats, (list, tuple)):
+        band_stats = "".join([_obj(b) for b in band_stats])
+    elif isinstance(band_stats, str):
+        pass
+    elif band_stats is None:
+        band_stats = ""
+    else:
+        raise ValueError(band_stats)
+    
+    return _pack("IH6xIQQII", meter_id, len, flow_count, packet_in_count, byte_in_count,
+        duration_sec, duration_nsec) + band_stats
+
+def ofp_meter_band_stats(packet_band_count, byte_band_count):
+    return _pack("QQ", packet_band_count, byte_band_count)
+
+# 7.3.5.13
+def ofp_meter_config(length, flags, meter_id, bands):
+    if isinstance(bands, (list,tuple)):
+        bands = "".join([_obj(b) for b in bands])
+    elif isinstance(bands, str):
+        pass
+    elif bands is None:
+        bands = ""
+    else:
+        raise ValueError(bands)
+    
+    length = 8 + _len(bands)
+    
+    return _pack("HHI", length, flags, meter_id) + bands
+
+# 7.3.5.14
+def ofp_meter_features(max_meter, band_types, capabilities, max_bands, max_color):
+    return _pack("IIIBB2x", max_meter, band_types, capabilities, max_bands, max_color)
+
+# 7.3.5.15
+def ofp_vendor_stats_header(experimenter, exp_type):
+    return _pack("II", experimenter, exp_type)
+
+# XXX
+
+# 7.3.6
+def ofp_queue_get_config_request(header, port):
+    return ofp_(header,
+        _pack("I4x", port),
+        OFPT_QUEUE_GET_CONFIG_REQUEST)
+
+def ofp_queue_get_config_reply(header, port, queues):
+    if isinstance(queues, (list,tuple)):
+        queues = "".join([_obj(q) for q in queues])
+    elif queues is str:
+        pass
+    elif queues is None:
+        queues = ""
+    else:
+        raise ValueError(queues)
+    
+    return ofp_(header,
+        _pack("I4x", port) + queues,
+        OFPT_QUEUE_GET_CONFIG_REPLY)
+
+# 7.3.7
+def ofp_packet_out(header, buffer_id, in_port, actions_len, actions, data):
+    if isinstance(actions, (list,tuple)):
+        actions = "".join([_obj(a) for a in actions])
+    elif isinstance(actions, str):
+        pass
+    elif actions is None:
+        actions = ""
+    else:
+        raise ValueError(actions)
+    
+    if isinstance(data, str):
+        pass
+    elif data is None:
+        data = ""
+    else:
+        raise ValueError(data)
+    
+    if buffer_id is None:
+        buffer_id = OFP_NO_BUFFER
+    
+    actions_len = _len(actions)
+    
+    return ofp_(header,
+        _pack("IIH6x", buffer_id, in_port, actions_len) + actions + data,
+        OFPT_PACKET_OUT)
+
+# 7.3.9
+def ofp_role_request(header, role, generation_id):
+    return ofp_(header,
+        _pack("I4xQ", role, generation_id),
+        (OFPT_ROLE_REQUEST, OFPT_ROLE_REPLY))
+
+# 7.4.1
+def ofp_packet_in(header, buffer_id, total_len, reason, table_id, cookie, match, data):
+    return ofp_(header,
+        _pack("IHBBQ", buffer_id, total_len, reason, table_id, cookie) + _obj(match) + "\0"*2 + data,
+        OFPT_PACKET_IN)
+
+# 7.4.2
+def ofp_flow_removed(header, cookie, priority, reason, table_id,
+        duration_sec, duration_nsec, idle_timeout, hard_timeout,
+        packet_count, byte_count, match):
+    return ofp_(header,
+        _pack("QHBBIIHHQQ", cookie, priority, reason, table_id,
+            duration_sec, duration_nsec, idle_timeout, hard_timeout,
+            packet_count, byte_count) + _obj(match),
+        OFPT_FLOW_REMOVED)
+
+# 7.4.3
+def ofp_port_status(header, reason, desc):
+    return ofp_(header,
+        _pack("B7x", reason) + _obj(desc),
+        OFP_PORT_STATUS)
+
+# 7.4.4
+def ofp_error_msg(header, type, code, data):
+    if data is None:
+        data = ""
+    return ofp_(header,
+        _pack("HH", type, code)+data,
+        OFPT_ERROR)
+
+# 7.5.1
+def ofp_hello(header, elements):
+    if isinstance(elements, str):
+        pass
+    elif isinstance(elements, (tuple, list)):
+        elements = "".join([_obj(e) for e in elements])
+    elif elements is None:
+        elements = ""
+    else:
+        raise ValueError(elements)
+    
+    return ofp_(header, elements, OFPT_HELLO)
+
+def ofp_hello_elem_header(type, length):
+    return _pack("HH", type, length)
+
+def ofp_hello_elem_versionbitmap(type, length, bitmaps):
+    if type is None:
+        type = 1
+    assert type == 1 # VERSIONBITMAP
+    
+    if isinstance(bitmaps, str):
+        pass
+    elif isinstance(bitmaps, (tuple, list)):
+        bitmaps = "".join([_pack("I",e) for e in bitmaps])
+    elif bitmaps is None:
+        bitmaps = ""
+    else:
+        raise ValueError("%s" % bitmaps)
+    
+    length = 4 + _len(bitmaps)
+    
+    return struct.pack("!HH", type, length) + bitmaps + '\0'*(_align(length)-length)
+
+# 7.5.4
+def ofp_experimenter_header(header, experimenter, exp_type, data):
+    return ofp_(header,
+        _pack("II", experimenter, exp_type) + data,
+        OFPT_EXPERIMENTER)
+

--- a/twink/ofp1/oxm.py
+++ b/twink/ofp1/oxm.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import
+import struct
+from collections import namedtuple
+from . import _enum_base
+
+ofp_oxm_class = type("ofp_oxm_class", (_enum_base,), {
+	"prefix": "OFPXMC",
+	"numbers": {
+		"NXM_0":          0x0000,
+		"NXM_1":          0x0001,
+		"OPENFLOW_BASIC": 0x8000,
+		"EXPERIMENTER":   0xFFFF }
+	})(globals())
+
+oxm_ofb_match_fields = type("oxm_ofb_match_fields", (_enum_base,), {
+	"prefix": "OXM_OF",
+	"numbers": '''IN_PORT IN_PHY_PORT METADATA
+		ETH_DST ETH_SRC ETH_TYPE VLAN_VID VLAN_PCP
+		IP_DSCP IP_ECN IP_PROTO IPV4_SRC IPV4_DST
+		TCP_SRC TCP_DST UDP_SRC UDP_DST SCTP_SRC SCTP_DST
+		ICMPV4_TYPE ICMPV4_CODE
+		ARP_OP ARP_SPA ARP_TPA ARP_SHA ARP_THA
+		IPV6_SRC IPV6_DST IPV6_FLABEL
+		ICMPV6_TYPE ICMPV6_CODE
+		IPV6_ND_TARGET IPV6_ND_SLL IPV6_ND_TLL
+		MPLS_LABEL MPLS_TC MPLS_BOS
+		PBB_ISID TUNNEL_ID IPV6_EXTHDR'''
+	})(globals())
+
+ofp_vlan_id = type("ofp_vlan_id", (_enum_base,), {
+	"prefix": "OFPVID",
+	"bitshifts": { "PRESENT":12, "NONE":-1 }
+	})(globals())
+
+ofp_ipv6exthdr_flags = type("ofp_ipv6exthdr_flags", (_enum_base,), {
+	"prefix": "OFPIEH",
+	"bitshifts": "NONEXT ESP AUTH DEST FRAG ROUTER HOP UNREP UNSEQ"
+	})(globals())
+
+def _bits(oxm_field):
+	if oxm_field in (OXM_OF_IN_PORT, OXM_OF_IN_PHY_PORT, OXM_OF_PBB_ISID):
+		bits = "I"
+	elif oxm_field in (OXM_OF_METADATA, OXM_OF_TUNNEL_ID):
+		bits = "Q"
+	elif oxm_field in (OXM_OF_ETH_DST, OXM_OF_ETH_SRC, OXM_OF_ARP_SHA, OXM_OF_ARP_THA,
+			OXM_OF_IPV6_ND_SLL, OXM_OF_IPV6_ND_TLL):
+		bits = "6s"
+	elif oxm_field in (OXM_OF_ETH_TYPE, OXM_OF_VLAN_VID,
+			OXM_OF_TCP_SRC, OXM_OF_TCP_DST, OXM_OF_UDP_SRC, OXM_OF_UDP_DST,
+			OXM_OF_SCTP_SRC, OXM_OF_SCTP_DST, OXM_OF_ARP_OP, OXM_OF_IPV6_EXTHDR):
+		bits = "H"
+	elif oxm_field in (OXM_OF_IPV4_SRC, OXM_OF_IPV4_DST,
+			OXM_OF_ARP_SPA, OXM_OF_ARP_TPA):
+		bits = "4s"
+	elif oxm_field in (OXM_OF_IPV6_SRC, OXM_OF_IPV6_DST, OXM_OF_IPV6_ND_TARGET):
+		bits = "16s"
+	else:
+		bits = "B"
+	return bits
+
+def parse(message, offset=0):
+	(oxm_class, p, oxm_length) = struct.unpack_from("!HBB", message, offset)
+	oxm_field = p>>1
+	oxm_hasmask = p&1
+	offset += 4
+	
+	if oxm_class != OFPXMC_OPENFLOW_BASIC:
+		raise ValueError("only OFPXMC_OPENFLOW_BASIC is supported")
+	
+	bits = _bits(oxm_field)
+	
+	if oxm_hasmask:
+		assert oxm_length == struct.calcsize("!"+bits*2)
+		return namedtuple("oxm", "oxm_class oxm_field oxm_hasmask oxm_length oxm_value oxm_mask")(
+			oxm_class, oxm_field, oxm_hasmask, oxm_length, *struct.unpack_from("!"+bits*2, message, offset))
+	else:
+		assert oxm_length == struct.calcsize(bits)
+		return namedtuple("oxm", "oxm_class oxm_field oxm_hasmask oxm_length oxm_value")(
+			oxm_class, oxm_field, oxm_hasmask, oxm_length, *struct.unpack_from("!"+bits, message, offset))
+
+def parse_list(message, offset=0):
+	ret = []
+	while offset < len(message):
+		m = parse(message, offset)
+		ret.append(m)
+		offset += 4 + m.oxm_length
+	return ret
+
+def build(oxm_class, oxm_field, oxm_hasmask, oxm_length, oxm_value, oxm_mask=None):
+	if oxm_class is None:
+		oxm_class = OFPXMC_OPENFLOW_BASIC
+	assert oxm_class == OFPXMC_OPENFLOW_BASIC
+	
+	bits = _bits(oxm_field)
+	
+	if oxm_hasmask:
+		oxm_hasmask = 1
+	else:
+		oxm_hasmask = 0
+	
+	if oxm_mask is None:
+		if oxm_hasmask:
+			oxm_mask = 0
+	else:
+		oxm_hasmask = 1
+	
+	if oxm_hasmask:
+		oxm_length = struct.calcsize("!"+bits*2)
+		return struct.pack("!HBB"+bits*2, oxm_class, (oxm_field<<1)+oxm_hasmask, oxm_length, oxm_value, oxm_mask)
+	else:
+		oxm_length = struct.calcsize("!"+bits)
+		return struct.pack("!HBB"+bits, oxm_class, (oxm_field<<1)+oxm_hasmask, oxm_length, oxm_value)

--- a/twink/ofp1/parse.py
+++ b/twink/ofp1/parse.py
@@ -1,0 +1,924 @@
+from __future__ import absolute_import
+import struct
+from collections import namedtuple
+from . import *
+
+_len = len
+_type = type
+
+def _align(length):
+    return (length+7)/8*8
+
+class _pos(object):
+    offset = 0
+
+def _cursor(offset):
+    if isinstance(offset, _pos):
+        return offset
+    elif isinstance(offset, int):
+        ret = _pos()
+        ret.offset = offset
+        return ret
+    else:
+        raise ValueError(offset)
+
+def _unpack(fmt, msg, offset):
+    cur = _cursor(offset)
+    
+    if fmt[0] != "!":
+        fmt = "!"+fmt
+    
+    ret = struct.unpack_from(fmt, msg, cur.offset)
+    cur.offset += struct.calcsize(fmt)
+    return ret
+
+def from_bitmap(uint32_t_list):
+    ret = []
+    for o,i in zip(range(_len(uint32_t_list)),uint32_t_list):
+        for s in range(32):
+            if i & (1<<s):
+                ret.append(32*o + s)
+    return ret
+
+def parse(message, offset=0):
+    if message is None:
+        return None
+    
+    cursor = _cursor(offset)
+    header = ofp_header(message, cursor.offset)
+    assert header.version == 1
+    if header.type == OFPT_HELLO:
+        return ofp_hello(message, cursor)
+    elif header.type == OFPT_ERROR:
+        return ofp_error_msg(message, cursor)
+    elif header.type == OFPT_FEATURES_REPLY:
+        return ofp_switch_features(message, cursor)
+    elif header.type in (OFPT_SET_CONFIG, OFPT_GET_CONFIG_REPLY):
+        return ofp_switch_config(message, cursor)
+    elif header.type == OFPT_PACKET_IN:
+        return ofp_packet_in(message, cursor)
+    elif header.type == OFPT_FLOW_REMOVED:
+        return ofp_flow_removed(message, cursor)
+    elif header.type == OFPT_PORT_STATUS:
+        return ofp_port_status(message, cursor)
+    elif header.type == OFPT_PACKET_OUT:
+        return ofp_packet_out(message, cursor)
+    elif header.type == OFPT_FLOW_MOD:
+        return ofp_flow_mod(message, cursor)
+    elif header.type == OFPT_PORT_MOD:
+        return ofp_port_mod(message, cursor)
+    elif header.type == OFPT_STATS_REQUEST:
+        return ofp_stats_request(message, cursor)
+    elif header.type == OFPT_STATS_REPLY:
+        return ofp_stats_reply(message, cursor)
+    elif header.type == OFPT_VENDOR:
+        return ofp_vendor_(message, cursor)
+    elif header.type == OFPT_QUEUE_GET_CONFIG_REQUEST:
+        return ofp_queue_get_config_request(message, cursor)
+    elif header.type == OFPT_QUEUE_GET_CONFIG_REPLY:
+        return ofp_queue_get_config_reply(message, cursor)
+    else:
+        # OFPT_ECHO_REQUEST, OFPT_ECHO_REPLY
+        # OFPT_FEATURES_REQUEST
+        # OFPT_BARRIER_REQUEST, OFPT_BARRIER_REPLY
+        # OFPT_GET_ASYNC_REQUEST
+        return ofp_(message, cursor)
+
+# 7.1
+def ofp_header(message, offset):
+    cursor = _cursor(offset)
+    (version, type, length, xid) = _unpack("BBHI", message, cursor)
+    assert version == 1
+    return namedtuple("ofp_header",
+        "version type length xid")(
+        version,type,length,xid)
+
+def ofp_(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    data = message[cursor.offset:offset+header.length]
+    cursor.offset = offset+header.length
+    return namedtuple("ofp_",
+        "header,data")(header, data)
+
+# 7.2.1 and 7.3.5.7
+def ofp_port(message, offset):
+    cursor = _cursor(offset)
+    p = list(_unpack("I4x6s2x16sII6I", message, cursor))
+    p[2] = p[2].partition("\0")[0]
+    return namedtuple("ofp_port", '''
+        port_no hw_addr name
+        config state
+        curr advertised supported peer
+        curr_speed max_speed''')(*p)
+
+# 7.2.2
+def ofp_packet_queue(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (queue_id,port,len) = _unpack("IIH6x", message, cursor)
+    properties = []
+    while cursor.offset < offset + len:
+        prop_header = ofp_queue_prop_header(message, cursor.offset)
+        if prop_header.property == OFPQT_MIN:
+            properties.append(ofp_queue_prop_min_rate(message, cursor))
+        elif prop_header.property == OFPQT_MAX:
+            properties.append(ofp_queue_prop_max_rate(message, cursor))
+        elif prop_header.property == OFPQT_VENDOR:
+            properties.append(ofp_queue_prop_vendor(message, cursor))
+        else:
+            raise ValueError(prop_header)
+    assert cursor.offset == offset + len
+    return namedtuple("ofp_packet_queue",
+        "queue_id port len properties")(queue_id,port,len,properties)
+
+def ofp_queue_prop_header(message, offset):
+    return namedtuple("ofp_queue_prop_header",
+        "property len")(*_unpack("HH4x", message, offset))
+
+def ofp_queue_prop_min_rate(message, offset):
+    cursor = _cursor(offset)
+    
+    prop_header = ofp_queue_prop_header(message, cursor)
+    
+    (rate,) = _unpack("H6x", message, cursor)
+    
+    return namedtuple("ofp_queue_prop_min_rate",
+        "prop_header rate")(prop_header, rate)
+
+def ofp_queue_prop_max_rate(message, offset):
+    cursor = _cursor(offset)
+    
+    prop_header = ofp_queue_prop_header(message, cursor)
+    
+    (rate,) = _unpack("H6x", message, cursor)
+    
+    return namedtuple("ofp_queue_prop_max_rate",
+        "prop_header rate")(prop_header, rate)
+
+def ofp_queue_prop_vendor(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    prop_header = ofp_queue_prop_header(message, cursor)
+    
+    (vendor,) = _unpack("I4x", message, cursor)
+    
+    data = message[cursor.offset:offset+prop_header.len]
+    cursor.offset = offset + prop_header.len
+    
+    return namedtuple("ofp_queue_prop_vendor",
+        "prop_header vendor data")(prop_header,vendor,data)
+
+# 7.2.3.1
+def ofp_match(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (wildcards,in_port) = _unpack("IH", message, cursor)
+    src_mac = message[cursor.offset:cursor.offset+6]
+    cursor.offset += 6
+    dst_mac = message[cursor.offset:cursor.offset+6]
+    cursor.offset += 6
+    (dl_vlan,dl_vlan_pcp,dl_type,nw_tos,nw_proto,
+        nw_src,nw_dst,tp_src,tp_dst) = _unpack("HBxH2B2x2I2H", message, cursor)
+    return namedtuple("ofp_match",
+        '''wildcards,in_port,src_mac,dst_mac,dl_vlan,dl_vlan_pcp
+        dl_type,nw_tos,nw_proto,nw_src,nw_dst,tp_src,tp_dst''')(
+        wildcards,in_port,src_mac,dst_mac,dl_vlan,dl_vlan_pcp,
+        dl_type,nw_tos,nw_proto,nw_src,nw_dst,tp_src,tp_dst)
+
+# 7.2.3.8
+def ofp_oxm_vendor_header(message, offset):
+    return namedtuple("ofp_oxm_vendor_header",
+        "oxm_header vendor")(*_unpack("II", message, offset))
+
+# 7.2.4
+def ofp_instruction(message, offset):
+    return namedtuple("ofp_instruction",
+        "type len")(*_unpack("HH", message, offset))
+
+def ofp_instruction_(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type, len) = ofp_instruction(message, cursor.offset)
+    if type == OFPIT_GOTO_TABLE:
+        return ofp_instruction_goto_table(message, cursor)
+    elif type == OFPIT_WRITE_METADATA:
+        return ofp_instruction_write_metadata(message, cursor)
+    elif type in (OFPIT_WRITE_ACTIONS, OFPIT_APPLY_ACTIONS, OFPIT_CLEAR_ACTIONS):
+        return ofp_instruction_actions(message, cursor)
+    elif type == OFPIT_METER:
+        return ofp_instruction_meter(message, cursor)
+    elif type == OFPIT_VENDOR:
+        return ofp_instruction_vendor(message, cursor)
+    else:
+        raise ValueError(ofp_instruction(message, cursor.offset))
+
+def ofp_instruction_goto_table(message, offset):
+    return namedtuple("ofp_instruction_goto_table",
+        "type len table_id")(*_unpack("HHB3x", message, offset))
+
+def ofp_instruction_write_metadata(message, offset):
+    return namedtuple("ofp_instruction_write_metadata",
+        "type len metadata metadata_mask")(*_unpack("HH4xQQ", message, offset))
+
+def ofp_instruction_actions(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,len) = _unpack("HH4x", message, cursor)
+    
+    actions = []
+    while cursor.offset < offset + len:
+        actions.append(ofp_action_(message,cursor))
+    
+    assert cursor.offset == offset+len
+    return namedtuple("ofp_instruction_actions",
+        "type,len,actions")(type,len,actions)
+
+def ofp_instruction_meter(message, offset):
+    return namedtuple("ofp_instruction_meter",
+        "type len meter_id")(*_unpack("HHI", message, offset))
+
+def ofp_instruction_vendor(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,len,vendor) = _unpack("HHI", message, cursor)
+    
+    data = message[cursor.offset:offset+len]
+    cursor.offset = offset+len
+    
+    return namedtuple("ofp_instruction_vendor",
+        "type len vendor data")(type,len,vendor,data)
+
+# 7.2.5
+def ofp_action_header(message, offset):
+    return namedtuple("ofp_action_header",
+        "type,len")(*_unpack("HH4x", message, offset))
+
+def ofp_action_(message, offset):
+    cursor = _cursor(offset)
+    header = ofp_action_header(message, cursor.offset)
+    if header.type == OFPAT_OUTPUT:
+        return ofp_action_output(message, cursor)
+    elif header.type == OFPAT_VENDOR:
+        return ofp_action_vendor_(message, cursor)
+    else:
+        return ofp_action_header(message, cursor)
+
+def ofp_action_output(message, offset):
+    return namedtuple("ofp_action_output",
+        "type,len,port,max_len")(*_unpack("4H", message, offset))
+
+def ofp_action_vendor_header(message, offset):
+    return namedtuple("ofp_action_vendor_header",
+        "type,len,vendor")(*_unpack("HHI", message, offset))
+
+def ofp_action_vendor_(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_action_vendor_header(message, cursor)
+    data = message[cursor.offset:offset+header.len]
+    cursor.offset = offset + header.len
+    return namedtuple("ofp_action_vendor_",
+        "type,len,vendor,data")(*header+(data,))
+
+# 7.3.1
+def ofp_switch_features(message, offset=0):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    (datapath_id, n_buffers, n_tables, 
+        auxiliary_id, capabilities, reserved) = _unpack("QIBB2xII", message, cursor)
+    return namedtuple("ofp_switch_features",
+        "header,datapath_id,n_buffers,n_tables,auxiliary_id,capabilities")(
+        header,datapath_id,n_buffers,n_tables,auxiliary_id,capabilities)
+
+# 7.3.2
+def ofp_switch_config(message, offset):
+    cursor = _cursor(offset)
+    
+    header = ofp_header(message, cursor)
+    (flags,miss_send_len) = _unpack("HH", message, cursor)
+    return namedtuple("ofp_switch_config",
+        "header,flags,miss_send_len")(header,flags,miss_send_len)
+
+# 7.3.4.1
+def ofp_flow_mod(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    match = ofp_match(message, cursor)
+    (cookie,command,idle_timeout,hard_timeout,
+        priority,buffer_id,out_port,flags) = _unpack("Q4HI2H", message, cursor)
+    actions = _list_fetch(message, cursor, offset+header.length, ofp_action_)
+    
+    return namedtuple("ofp_flow_mod",
+        '''header,match,cookie,command,idle_timeout,hard_timeout,
+        priority,buffer_id,out_port,flags,actions''')(
+        header,match,cookie,command,idle_timeout,hard_timeout,
+        priority,buffer_id,out_port,flags,actions)
+
+def ofp_bucket(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (len,weight,watch_port,watch_group)=_unpack("HHII4x", message, cursor)
+    actions = []
+    while cursor.offset < offset+len:
+        actions.append(ofp_action_(message, cursor))
+    
+    return namedtuple("ofp_bucket",
+        "len weight watch_port watch_group actions")(
+        len,weight,watch_port,watch_group,actions)
+
+# 7.3.4.3
+def ofp_port_mod(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (port_no, hw_addr, config, advertise) = _unpack("I4x6s2xIII4x", message, offset)
+    assert offset + header.length == cursor.offset
+    return namedtuple("ofp_port_mod",
+        "header,port_no,hw_addr,config,advertise")(
+        header,port_no,hw_addr,config,advertise)
+
+def ofp_meter_band_header(message, offset):
+    return namedtuple("ofp_meter_band_header",
+        "type,len,rate,burst_size")(*_unpack("HHII", message, offset))
+
+def ofp_meter_band_(message, offset):
+    cursor = _cursor(offset)
+    
+    header = ofp_meter_band_header(message, cursor.offset)
+    if header.type == OFPMBT_DROP:
+        return ofp_meter_band_drop(message, cursor)
+    elif header.type == OFPMBT_DSCP_REMARK:
+        return ofp_meter_band_dscp_remark(message, cursor)
+    elif header.type == OFPMBT_vendor:
+        return ofp_meter_band_vendor(message, cursor)
+    else:
+        raise ValueError(header)
+
+def ofp_meter_band_drop(message, offset):
+    return namedtuple("ofp_meter_band_drop",
+        "type,len,rate,burst_size")(*_unpack("HHII4x", message, offset))
+
+def ofp_meter_band_dscp_remark(message, offset):
+    return namedtuple("ofp_meter_band_dscp_remark",
+        "type,len,rate,burst_size,prec_level")(
+        *_unpack("HHIIB3x", message, offset))
+
+def ofp_meter_band_vendor(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,len,rate,burst_size,vendor) = _unpack("HH3I", message, offset)
+    data = message[cursor.offset:offset+len]
+    return namedtuple("ofp_meter_band_vendor",
+        "type,len,rate,burst_size,vendor,data")(
+        type,len,rate,burst_size,vendor,data)
+
+# 7.3.5
+def ofp_stats_request(message, offset=0):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (type, flags) = _unpack("HH", message, cursor)
+    if type in (OFPST_DESC, OFPST_TABLE):
+        body = ""
+    elif type == OFPST_FLOW:
+        body = ofp_flow_stats_request(message, cursor)
+    elif type == OFPST_AGGREGATE:
+        body = ofp_aggregate_stats_request(message, cursor)
+    elif type == OFPST_PORT:
+        body = ofp_port_stats_request(message, cursor)
+    elif type == OFPST_QUEUE:
+        body = ofp_queue_stats_request(message, cursor)
+    elif type == OFPST_VENDOR:
+        body = message[cursor.offset:offset+header.length]
+        cursor.offset = offset + header.length
+    else:
+        raise ValueError("stats type=%d flags=%s" % (type, flags))
+    
+    return namedtuple("ofp_stats_request",
+        "header type flags body")(header,type,flags,body)
+
+def ofp_stats_reply(message, offset=0):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (type, flags) = _unpack("HH4x", message, cursor)
+    body = []
+    if type == OFPST_DESC:
+        body = ofp_desc(message, cursor)
+    elif type == OFPST_FLOW:
+        body = _list_fetch(message, cursor, offset + header.length, ofp_flow_stats)
+    elif type == OFPST_AGGREGATE:
+        body = _list_fetch(message, cursor, offset + header.length, ofp_aggregate_stats_reply)
+    elif type == OFPST_TABLE:
+        body = _list_fetch(message, cursor, offset + header.length, ofp_table_stats)
+    elif type == OFPST_PORT:
+        body = _list_fetch(message, cursor, offset + header.length, ofp_port_stats)
+    elif type == OFPST_QUEUE:
+        body = _list_fetch(message, cursor, offset + header.length, ofp_queue_stats)
+    elif type == OFPST_VENDOR:
+        body = ofp_vendor_stats_(message, cursor, offset+header.length)
+    else:
+        raise ValueError("stats type=%d flags=%s" % (type, flags))
+    
+    return namedtuple("ofp_stats_reply",
+        "header type flags body")(header,type,flags,body)
+
+def _list_fetch(message, cursor, limit, fetcher):
+    ret = []
+    while cursor.offset < limit:
+        ret.append(fetcher(message, cursor))
+    
+    assert cursor.offset == limit
+    return ret
+
+# 7.3.5.1
+def ofp_desc(message, offset):
+    return namedtuple("ofp_desc",
+        "mfr_desc,hw_desc,sw_desc,serial_num,dp_desc")(*_unpack("256s256s256s32s256s", message, offset))
+
+# 7.3.5.2
+def ofp_flow_stats_request(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (table_id,out_port,out_group,cookie,cookie_mask) = _unpack("B3xII4xQQ", message, cursor)
+    
+    match = ofp_match(message, cursor)
+    
+    return namedtuple("ofp_flow_stats_request",
+        "table_id,out_port,out_group,cookie,cookie_mask,match")(
+        table_id,out_port,out_group,cookie,cookie_mask,match)
+
+def ofp_flow_stats(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (length,table_id,duration_sec,duration_nsec,priority,
+    idle_timeout,hard_timeout,flags,cookie,
+    packet_count,byte_count) = _unpack("HBxII4H4x3Q", message, cursor)
+    
+    match = ofp_match(message, cursor)
+    
+    instructions = _list_fetch(message, cursor, offset+length, ofp_instruction_)
+    
+    return namedtuple("ofp_flow_stats", '''
+        length table_id duration_sec duration_nsec
+        priority idle_timeout hard_timeout flags cookie
+        packet_count byte_count match instructions''')(
+        length,table_id,duration_sec,duration_nsec,priority,
+        idle_timeout,hard_timeout,flags,cookie,
+        packet_count,byte_count,match,instructions)
+
+# 7.3.5.3
+def ofp_aggregate_stats_request(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (table_id,out_port,out_group,cookie,cookie_mask) = _unpack("B3xII4xQQ", message, cursor)
+    match = ofp_match(message, cursor)
+    
+    return namedtuple("ofp_aggregate_stats_request",
+        "table_id,out_port,out_group,cookie,cookie_mask,match")(
+        table_id,out_port,out_group,cookie,cookie_mask,match)
+
+def ofp_aggregate_stats_reply(message, offset):
+    return namedtuple("ofp_aggregate_stats_reply",
+        "packet_count,byte_count,flow_count")(
+        *_unpack("QQI4x", message, offset))
+
+# 7.3.5.4
+def ofp_table_stats(message, offset):
+    return namedtuple("ofp_table_stats", "table_id,out_port,out_group,cookie,cookie_mask")(
+        *_unpack("B3xIQQ", message, offset))
+
+# 7.3.5.5.1
+def ofp_table_features(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (length,table_id,name,metadata_match,metadata_write,config,max_entries) = _unpack("HB5x32sQQII", message, cursor)
+    properties = _list_fetch(message, cursor, offset+length, ofp_table_feature_prop_)
+    
+    name = name.partition('\0')[0]
+    
+    return namedtuple("ofp_table_feature_prop_header",
+        "length,table_id,name,metadata_match,metadata_write,config,max_entries,properties")(
+        length,table_id,name,metadata_match,metadata_write,config,max_entries,properties)
+
+# 7.3.5.5.2
+def ofp_table_feature_prop_header(message, offset):
+    return namedtuple("ofp_table_feature_prop_header",
+        "type,length")(*_unpack("HH", message, offset))
+
+def ofp_table_feature_prop_instructions(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,length) = _unpack("HH", message, cursor)
+    instruction_ids = []
+    while cursor.offset < offset+length:
+        header = ofp_instruction(cursor.offset)
+        if header.type == OFPIT_VENDOR:
+            instruction_ids.append(ofp_instruction_vendor(message, cursor))
+        else:
+            assert header.len == 4
+            instruction_ids.append(header)
+    cursor.offset += _align(length)-length
+    
+    return namedtuple("ofp_table_feature_prop_instructions",
+        "type,length,instruction_ids")(
+        type,length,instruction_ids)
+
+def ofp_table_feature_prop_next_tables(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,length) = _unpack("HH", message, cursor)
+    next_table_ids = _unpack("%dB" % (length-4), message, offset)
+    cursor.offset += _align(length)-length
+    
+    return namedtuple("ofp_table_feature_prop_next_tables",
+        "type,length,next_table_ids")(type,length,next_table_ids)
+
+def ofp_table_feature_prop_actions(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,length) = _unpack("HH", message, cursor)
+    action_ids = []
+    while cursor.offset < offset+length:
+        header = ofp_action_header(message, cursor.offset)
+        if header.type == OFPAT_VENDOR:
+            action_ids.append(ofp_action_vendor(message, cursor))
+        else:
+            assert header.len == 4
+            action_ids.append(header)
+    cursor.offset += _align(length)-length
+    
+    return namedtuple("ofp_table_feature_prop_actions",
+        "type,length,action_ids")(type,length,action_ids)
+
+def ofp_table_feature_prop_oxm(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,length) = _unpack("HH", message, cursor)
+    oxm_ids = _unpack("%dI" % ((length-4)/4), message, cursor)
+    cursor.offset += _align(length)-length
+    
+    return namedtuple("ofp_table_feature_prop_oxm",
+        "type,length,oxm_ids")(type,length,oxm_ids)
+
+def ofp_table_feature_prop_vendor(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (type,length,vendor,exp_type) = _unpack("HHII", message, cursor)
+    data = message[cursor.offset:offset+length]
+    cursor.offset += _align(length)-length
+    
+    return namedtuple("ofp_table_feature_prop_vendor",
+        "type,length,vendor,exp_type,data")(
+        type,length,vendor,exp_type,data)
+
+# 7.3.5.6
+def ofp_port_stats_request(message, offset):
+    return namedtuple("ofp_port_stats_request",
+        "port_no")(*_unpack("H6x", message, offset))
+
+def ofp_port_stats(message, offset):
+    return namedtuple("ofp_port_stats", '''
+        port_no
+        rx_packets tx_packets
+        rx_bytes tx_bytes
+        rx_dropped tx_dropped
+        rx_errors tx_errors
+        rx_frame_err
+        rx_over_err
+        rx_crc_err
+        collisions''')(*_unpack("H6x12Q", message, offset))
+
+# 7.3.5.8
+def ofp_queue_stats_request(message, offset):
+    return namedtuple("ofp_queue_stats_request",
+        "port_no queue_id")(*_unpack("II", message, offset))
+
+def ofp_queue_stats(message, offset):
+    return namedtuple("ofp_queue_stats", '''
+        port_no queue_id
+        tx_bytes tx_packets tx_errors
+        duration_sec duration_nsec''')(*_unpack("2I3Q2I", message, offset))
+
+# 7.3.5.9
+def ofp_group_stats_request(message, offset):
+    return namedtuple("ofp_group_stats_request",
+        "group_id")(*_unpack("I4x", message, offset))
+
+def ofp_group_stats(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (length, group_id, ref_count, packet_count, byte_count,
+        duration_sec, duration_nsec) = _unpack("H2xII4xQQII", message, cursor)
+    bucket_stats = _list_fetch(message, cursor, offset+length, ofp_bucket_counter)
+    return namedtuple("ofp_group_stats", '''
+        length group_id ref_count packet_count byte_count
+        duration_sec duration_nsec bucket_stats''')(
+        length,group_id,ref_count,packet_count,byte_count,
+        duration_sec,duration_nsec,bucket_stats)
+
+def ofp_bucket_counter(message, offset):
+    return namedtuple("ofp_bucket_counter",
+        "packet_count byte_count")(*_unpack("QQ", message, offset))
+
+# 7.3.5.10
+def ofp_group_desc(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (length, type, group_id) = _unpack("HBxI", message, cursor)
+    buckets = _list_fetch(message, cursor, offset+length, ofp_bucket)
+    return namedtuple("ofp_group_desc",
+        "length type group_id buckets")(
+        length,type,group_id,buckets)
+
+# 7.3.5.11
+def ofp_group_features(message, offset):
+    cursor = _cursor(offset)
+    (type,capabilities) = _unpack("II", message, cursor)
+    max_groups = _unpack("4I", message, cursor)
+    actions = _unpack("4I", message, cursor)
+    return namedtuple("ofp_group_features",
+        "type,capabilities,max_groups,actions")(
+        type,capabilities,max_groups,actions)
+
+# 7.3.5.12
+def ofp_meter_stats_request(message, offset):
+    # and 7.3.5.13
+    return namedtuple("ofp_meter_stats_request",
+        "meter_id")(*_unpack("I4x", message, offset))
+
+def ofp_meter_stats(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (meter_id,len,flow_count,packet_in_count,byte_in_count,
+        duration_sec,duration_nsec) = _unpack("IH6xIQQII", message, cursor)
+    
+    band_stats = _list_fetch(message, cursor, offset+len, ofp_meter_band_stats)
+    
+    return namedtuple("ofp_meter_stats", '''
+        meter_id len flow_count packet_in_count byte_in_count 
+        duration_sec duration_nsec band_stats''')(
+        meter_id,len,flow_count,packet_in_count,byte_in_count,
+        duration_sec,duration_nsec,band_stats)
+
+def ofp_meter_band_stats(message, offset):
+    return namedtuple("ofp_meter_band_stats",
+        "packet_band_count,byte_band_count")(*_unpack("QQ", message, offset))
+
+# 7.3.5.13
+def ofp_meter_config(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (length,flags,meter_id) = _unpack("HHI", message, cursor)
+    bands = _list_fetch(message, cursor, offset+length, ofp_meter_band_)
+    
+    return namedtuple("ofp_meter_config",
+        "length,flags,meter_id,bands")(
+        length,flags,meter_id,bands)
+
+# 7.3.5.14
+def ofp_meter_features(message, offset):
+    return namedtuple("ofp_meter_features", '''
+        max_meter band_types capabilities
+        max_bands max_color''')(*_unpack("3IBB2x", message, offset))
+
+# 7.3.5.15
+def ofp_vendor_stats_header(message, offset):
+    return namedtuple("ofp_vendor_stats_header",
+        "vendor,exp_type")(*_unpack("II", message, offset))
+
+def ofp_vendor_stats(message, offset, limit):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (vendor,exp_type) = ofp_vendor_stats_header(message, cursor)
+    data = message[cursor.offset:limit]
+    cursor.offset = limit
+    
+    return namedtuple("ofp_vendor_stats_",
+        "vendor,exp_type,data")(vendor,exp_type,data)
+
+# 7.3.6
+def ofp_queue_get_config_request(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    (port,) = _unpack("I4x", message, cursor)
+    return namedtuple("ofp_queue_get_config_request",
+        "header,port")(header,port)
+
+def ofp_queue_get_config_reply(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    (port,) = _unpack("I4x", message, cursor)
+    queues = _list_fetch(message, cursor, offset+header.length, ofp_packet_queue)
+    
+    return namedtuple("ofp_queue_get_config_reply",
+        "header,port,queues")(header,port,queues)
+
+# 7.3.7
+def ofp_packet_out(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (buffer_id, in_port, actions_len) = _unpack("IIH6x", message, cursor)
+    
+    actions_end = cursor.offset + actions_len
+    actions = []
+    while cursor.offset < actions_end:
+        actions.append(ofp_action_(message, cursor))
+    
+    data = message[cursor.offset:offset+header.length]
+    
+    return namedtuple("ofp_packet_out",
+        "header,buffer_id,in_port,actions_len,actions,data")(
+        header,buffer_id,in_port,actions_len,actions,data)
+
+# 7.3.9
+def ofp_role_request(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    (role,generation_id) = _unpack("I4xQ", message, cursor)
+    
+    return namedtuple("ofp_role_request",
+        "header,role,generation_id")(header,role,generation_id)
+
+# 7.3.10
+def ofp_async_config(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    p = _unpack("6I", message, cursor)
+    
+    return namedtuple("ofp_async_config",
+        "header,packet_in_mask,port_status_mask,flow_removed_mask")(
+        header,p[0:2],p[2:4],p[4:6])
+
+# 7.4.1
+def ofp_packet_in(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (buffer_id, total_len, reason, table_id, cookie) = _unpack("IHBBQ", message, cursor)
+    
+    match = ofp_match(message, cursor)
+    _unpack("2x", message, cursor);
+    data = message[cursor.offset:offset+header.length]
+    
+    return namedtuple("ofp_packet_in",
+        "header,buffer_id,total_len,reason,table_id,cookie,match,data")(
+        header,buffer_id,total_len,reason,table_id,cookie,match,data)
+
+# 7.4.2
+def ofp_flow_removed(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (cookie,priority,reason,table_id,
+    duration_sec,duration_nsec,
+    idle_timeout,hard_timeout,packet_count,byte_count) = _unpack("QHBBIIHHQQ", message, cursor)
+    
+    match = ofp_match(message, cursor)
+    
+    return namedtuple("ofp_flow_removed",
+        '''header cookie priority reason table_id 
+        duration_sec duration_nsec 
+        idle_timeout hard_timeout packet_count byte_count
+        match''')(
+        header,cookie,priority,reason,table_id,
+        duration_sec,duration_nsec,
+        idle_timeout,hard_timeout,packet_count,byte_count,
+        match)
+
+# 7.4.3
+def ofp_port_status(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (reason,) = _unpack("B7x", message, cursor)
+    
+    desc = ofp_port(message, cursor)
+    return namedtuple("ofp_port_status",
+        "header,reason,desc")(
+        header,reason,desc)
+
+# 7.4.4
+def ofp_error_msg(message, offset=0):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    (type, code) = _unpack("HH", message, cursor)
+    
+    data = message[cursor.offset:offset+header.length]
+    cursor.offset = offset + header.length
+    
+    return namedtuple("ofp_error_msg",
+        "header,type,code,data")(header,type,code,data)
+
+# 7.5.1
+def ofp_hello(message, offset=0):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    
+    elements = []
+    while cursor.offset < offset + header.length:
+        elem_header = ofp_hello_elem_header(message, cursor.offset)
+        
+        if elem_header.type == 1:
+            elements.append(ofp_hello_elem_versionbitmap(message, cursor))
+        else:
+            raise ValueError("message offset=%d %s" % (cursor.offset, elem_header))
+    
+    assert cursor.offset == offset + header.length
+    return namedtuple("ofp_hello", "header elements")(header, elements)
+
+def ofp_hello_elem_header(message, offset):
+    return namedtuple("ofp_hello_elem_header",
+        "type length")(*_unpack("HH", message, offset))
+
+def ofp_hello_elem_versionbitmap(message, offset):
+    cursor = _cursor(offset)
+    (type, length) = _unpack("HH", message, cursor)
+    assert type == OFPHET_VERSIONBITMAP
+    
+    bitmaps = _unpack("%dI" % ((length-4)/4), message, cursor)
+    cursor.offset += _align(length) - length
+    
+    return namedtuple("ofp_hello_elem_versionbitmap",
+        "type length bitmaps")(type,length,bitmaps)
+
+# 7.5.4
+def ofp_vendor_header(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    header = ofp_header(message, cursor)
+    (vendor,exp_type) = _unpack("II", message, cursor)
+    return namedtuple("ofp_vendor_header",
+        "header,vendor,exp_type")(header,vendor,exp_type)
+
+def ofp_vendor_(message, offset):
+    cursor = _cursor(offset)
+    offset = cursor.offset
+    
+    (header,vendor,exp_type) = ofp_vendor_header(message, cursor)
+    
+    data = message[cursor.offset:offset+length]
+    cursor.offset = offset+length
+    
+    return namedtuple("ofp_vendor_",
+        "header,vendor,exp_type,data")(header,vendor,exp_type,data)


### PR DESCRIPTION
The twink README claims support for OpenFlow 1.0, but when running a sample application against OpenDaylight (older Hydrogen build that only supports 1.0) it became apparent that there were enough changes between 1.0 and 1.3 that backwards compatibility was an issue.  These changes duplicate the ofp3 directory into an ofp1 and modify it to fit the OpenFlow 1.0 standard.